### PR TITLE
refactor: remove "global" from "jest/global": true

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -2,7 +2,7 @@
     "env": {
         "browser": true,
         "es2021": true,
-        "jest/globals": true
+        "jest": true
     },
     "extends": [
         "airbnb-base"


### PR DESCRIPTION
having "global" was causing eslint to not call out
errors in javascript code. removing it caused errors
that should be appearing to appear.

Removing it also allowed "test" and "expect" to not
appear as errors. Which was the intent of adding
this line of code.